### PR TITLE
Refactor Aggregate constructor syntax

### DIFF
--- a/backend/Common/Common.Domain/Model/Aggregate.cs
+++ b/backend/Common/Common.Domain/Model/Aggregate.cs
@@ -1,23 +1,11 @@
 namespace Common.Domain.Model;
 
-public abstract class Aggregate : Entity
+public abstract class Aggregate(Guid id, int version = 0) : Entity
 {
-    private readonly List<DomainEvent> _uncommittedEvents = new List<DomainEvent>();
+    private readonly List<DomainEvent> _uncommittedEvents = [];
 
-    protected Aggregate(Guid id)
-    {
-        Id = id;
-        Version = 0;
-    }
-    
-    protected Aggregate(Guid id, int version)
-    {
-        Id = id;
-        Version = version;
-    }
-
-    public Guid Id { get; }
-    public int Version { get; private set; }
+    public Guid Id { get; } = id;
+    public int Version { get; private set; } = version;
 
     public IEnumerable<DomainEvent> DomainEvents => _uncommittedEvents;
 
@@ -39,7 +27,7 @@ public abstract class Aggregate : Entity
     private void ApplyEvent(DomainEvent domainEvent, bool isFromHistory)
     {
         ApplyEvent(domainEvent);
-
+        
         if (!isFromHistory)
         {
             _uncommittedEvents.Add(domainEvent);


### PR DESCRIPTION
Simplify the `Aggregate` class constructor using the new positional syntax and initialize fields directly in the constructor. This change improves code readability and reduces redundancy in initializing the `id` and `version` fields.